### PR TITLE
fix: pass onchain fee parameter through to Ark SDK

### DIFF
--- a/lib/src/rust/api/ark_api.dart
+++ b/lib/src/rust/api/ark_api.dart
@@ -65,9 +65,16 @@ Future<Addresses> address({BigInt? amount}) =>
 Future<List<Transaction>> txHistory() =>
     RustLib.instance.api.crateApiArkApiTxHistory();
 
-Future<String> send({required String address, required BigInt amountSats}) =>
-    RustLib.instance.api
-        .crateApiArkApiSend(address: address, amountSats: amountSats);
+Future<String> send({
+  required String address,
+  required BigInt amountSats,
+  BigInt? feeSats,
+}) =>
+    RustLib.instance.api.crateApiArkApiSend(
+      address: address,
+      amountSats: amountSats,
+      feeSats: feeSats,
+    );
 
 /// Pay a BOLT11 Lightning invoice using Ark funds via Boltz submarine swap
 Future<LnPaymentResult> payLnInvoice({required String invoice}) =>

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -111,7 +111,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 [[package]]
 name = "ark-bdk-wallet"
 version = "0.7.0"
-source = "git+https://github.com/lendasat/arkade-rust-sdk.git?branch=feat%2Fcollaborative_redeem_with_vtxos#aa64ca7ecd0d7bfd4a7a8bcb6822c18744e8b9d8"
+source = "git+https://github.com/lendasat/arkade-rust-sdk.git?branch=feat%2Fcollaborative_redeem_with_vtxos#fecf6aa2fa387369a617208c1c5e4060ff55d885"
 dependencies = [
  "anyhow",
  "ark-client 0.7.0 (git+https://github.com/lendasat/arkade-rust-sdk.git?branch=feat%2Fcollaborative_redeem_with_vtxos)",
@@ -130,7 +130,7 @@ dependencies = [
 [[package]]
 name = "ark-client"
 version = "0.7.0"
-source = "git+https://github.com/lendasat/arkade-rust-sdk.git?branch=feat%2Fcollaborative_redeem_with_vtxos#aa64ca7ecd0d7bfd4a7a8bcb6822c18744e8b9d8"
+source = "git+https://github.com/lendasat/arkade-rust-sdk.git?branch=feat%2Fcollaborative_redeem_with_vtxos#fecf6aa2fa387369a617208c1c5e4060ff55d885"
 dependencies = [
  "ark-core",
  "ark-grpc 0.7.0 (git+https://github.com/lendasat/arkade-rust-sdk.git?branch=feat%2Fcollaborative_redeem_with_vtxos)",
@@ -203,7 +203,7 @@ dependencies = [
 [[package]]
 name = "ark-core"
 version = "0.7.0"
-source = "git+https://github.com/lendasat/arkade-rust-sdk.git?branch=feat%2Fcollaborative_redeem_with_vtxos#aa64ca7ecd0d7bfd4a7a8bcb6822c18744e8b9d8"
+source = "git+https://github.com/lendasat/arkade-rust-sdk.git?branch=feat%2Fcollaborative_redeem_with_vtxos#fecf6aa2fa387369a617208c1c5e4060ff55d885"
 dependencies = [
  "ark-secp256k1",
  "bech32",
@@ -221,7 +221,7 @@ dependencies = [
 [[package]]
 name = "ark-grpc"
 version = "0.7.0"
-source = "git+https://github.com/lendasat/arkade-rust-sdk.git?branch=feat%2Fcollaborative_redeem_with_vtxos#aa64ca7ecd0d7bfd4a7a8bcb6822c18744e8b9d8"
+source = "git+https://github.com/lendasat/arkade-rust-sdk.git?branch=feat%2Fcollaborative_redeem_with_vtxos#fecf6aa2fa387369a617208c1c5e4060ff55d885"
 dependencies = [
  "ark-core",
  "async-stream",
@@ -257,7 +257,7 @@ dependencies = [
 [[package]]
 name = "ark-rest"
 version = "0.7.0"
-source = "git+https://github.com/lendasat/arkade-rust-sdk.git?branch=feat%2Fcollaborative_redeem_with_vtxos#aa64ca7ecd0d7bfd4a7a8bcb6822c18744e8b9d8"
+source = "git+https://github.com/lendasat/arkade-rust-sdk.git?branch=feat%2Fcollaborative_redeem_with_vtxos#fecf6aa2fa387369a617208c1c5e4060ff55d885"
 dependencies = [
  "ark-core",
  "base64 0.22.1",
@@ -289,7 +289,7 @@ dependencies = [
 [[package]]
 name = "ark-secp256k1"
 version = "0.31.0"
-source = "git+https://github.com/lendasat/arkade-rust-sdk.git?branch=feat%2Fcollaborative_redeem_with_vtxos#aa64ca7ecd0d7bfd4a7a8bcb6822c18744e8b9d8"
+source = "git+https://github.com/lendasat/arkade-rust-sdk.git?branch=feat%2Fcollaborative_redeem_with_vtxos#fecf6aa2fa387369a617208c1c5e4060ff55d885"
 dependencies = [
  "bitcoin_hashes",
  "rand 0.9.2",
@@ -3377,7 +3377,7 @@ dependencies = [
 [[package]]
 name = "secp256k1-sys"
 version = "0.11.0"
-source = "git+https://github.com/lendasat/arkade-rust-sdk.git?branch=feat%2Fcollaborative_redeem_with_vtxos#aa64ca7ecd0d7bfd4a7a8bcb6822c18744e8b9d8"
+source = "git+https://github.com/lendasat/arkade-rust-sdk.git?branch=feat%2Fcollaborative_redeem_with_vtxos#fecf6aa2fa387369a617208c1c5e4060ff55d885"
 dependencies = [
  "cc",
 ]

--- a/rust/src/api/ark_api.rs
+++ b/rust/src/api/ark_api.rs
@@ -221,9 +221,10 @@ pub async fn tx_history() -> Result<Vec<Transaction>> {
     Ok(txs)
 }
 
-pub async fn send(address: String, amount_sats: u64) -> Result<String> {
+pub async fn send(address: String, amount_sats: u64, fee_sats: Option<u64>) -> Result<String> {
     let amount = bitcoin::Amount::from_sat(amount_sats);
-    let txid = crate::ark::client::send(address, amount).await?;
+    let fee = fee_sats.map(bitcoin::Amount::from_sat);
+    let txid = crate::ark::client::send(address, amount, fee).await?;
     Ok(txid.to_string())
 }
 

--- a/rust/src/ark/client.rs
+++ b/rust/src/ark/client.rs
@@ -159,7 +159,7 @@ pub async fn tx_history() -> Result<Vec<Transaction>> {
     }
 }
 
-pub async fn send(address: String, amount: Amount) -> Result<Txid> {
+pub async fn send(address: String, amount: Amount, fee: Option<Amount>) -> Result<Txid> {
     let maybe_client = ARK_CLIENT.try_get();
 
     match maybe_client {
@@ -214,6 +214,7 @@ pub async fn send(address: String, amount: Amount) -> Result<Txid> {
                         vtxo_outpoints.into_iter(),
                         address.assume_checked(),
                         amount,
+                        fee,
                     )
                     .await
                     .map_err(|e| anyhow!("Failed sending onchain {e:#}"))?;


### PR DESCRIPTION
The fee_sats parameter was missing from the send flow, meaning user-selected onchain fees were never actually applied. This adds an optional fee parameter from Dart through the Rust API layer down to collaborative_redeem_vtxo_selection.